### PR TITLE
chore: fix typo

### DIFF
--- a/pkg/yml/destination.go
+++ b/pkg/yml/destination.go
@@ -22,8 +22,8 @@ import "github.com/apache/apisix-control-plane/pkg/mem"
 func (d *Destination) ToMem() []mem.MemModel {
 	result := make([]mem.MemModel, 0)
 	for _, s := range d.Subsets {
-		fullName := *d.Kind + seprator + *d.Name + seprator + *s.Name
-		group := *d.Kind + seprator + *d.Name
+		fullName := *d.Kind + separator + *d.Name + separator + *s.Name
+		group := *d.Kind + separator + *d.Name
 		upstream := &mem.Upstream{
 			Kind:     d.Kind,
 			Name:     d.Name,

--- a/pkg/yml/gateway.go
+++ b/pkg/yml/gateway.go
@@ -21,7 +21,7 @@ import "github.com/apache/apisix-control-plane/pkg/mem"
 
 func (g *Gateway) ToMem() []mem.MemModel {
 	result := make([]mem.MemModel, 0)
-	fullName := *g.Kind + seprator + *g.Name
+	fullName := *g.Kind + separator + *g.Name
 	servers := make([]*mem.Server, 0)
 	for _, e := range g.Servers {
 		server := e.ToMem()

--- a/pkg/yml/model.go
+++ b/pkg/yml/model.go
@@ -19,7 +19,7 @@ package yml
 
 import "github.com/apache/apisix-control-plane/pkg/mem"
 
-const seprator = ":"
+const separator = ":"
 
 type YmlModel interface {
 	ToMem() []mem.MemModel

--- a/pkg/yml/rule.go
+++ b/pkg/yml/rule.go
@@ -21,7 +21,7 @@ import "github.com/apache/apisix-control-plane/pkg/mem"
 
 func (r *Rule) ToMem() []mem.MemModel {
 	result := make([]mem.MemModel, 0)
-	fullName := *r.Kind + seprator + *r.Name
+	fullName := *r.Kind + separator + *r.Name
 	for _, http := range r.HTTP {
 		route := &mem.Route{
 			Kind:     r.Kind,


### PR DESCRIPTION
seprator should be separator