### PR TITLE
chore: fix Go code styles

### DIFF
--- a/pkg/adapter/route.go
+++ b/pkg/adapter/route.go
@@ -18,9 +18,10 @@
 package adapter
 
 import (
+	"reflect"
+
 	"github.com/apache/apisix-control-plane/pkg/dp/apisix"
 	"github.com/apache/apisix-control-plane/pkg/mem"
-	"reflect"
 )
 
 func ToRoute(r *mem.Route) *apisix.Route {

--- a/pkg/yml/plugin.go
+++ b/pkg/yml/plugin.go
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package yml
 
 import "github.com/apache/apisix-control-plane/pkg/mem"


### PR DESCRIPTION
Run `gofmt -w ./pkg` to fix some Go code styles.

Signed-off-by: imjoey <majunjie@apache.org>